### PR TITLE
Fix 12.1 to work with our pinned `nixpkgs`

### DIFF
--- a/Web/Scotty/Action.hs
+++ b/Web/Scotty/Action.hs
@@ -37,8 +37,9 @@ module Web.Scotty.Action
 import           Blaze.ByteString.Builder   (fromLazyByteString)
 
 import qualified Control.Exception          as E
+import           Control.Monad              (liftM, when)
 import           Control.Monad.Error.Class
-import           Control.Monad.Reader       hiding (mapM)
+import           Control.Monad.Reader
 import qualified Control.Monad.State.Strict as MS
 import           Control.Monad.Trans.Except
 

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -161,7 +161,6 @@ newtype ActionT e m a = ActionT { runAM :: ExceptT (ActionError e) (ReaderT Acti
     deriving ( Functor, Applicative, MonadIO )
 
 instance (Monad m, ScottyError e) => Monad (ActionT e m) where
-    return = ActionT . return
     ActionT m >>= k = ActionT (m >>= runAM . k)
 #if !(MIN_VERSION_base(4,13,0))
     fail = Fail.fail

--- a/Web/Scotty/Internal/Types.hs
+++ b/Web/Scotty/Internal/Types.hs
@@ -14,6 +14,7 @@ import           Blaze.ByteString.Builder (Builder)
 import           Control.Applicative
 import           Control.Exception (Exception)
 import qualified Control.Exception as E
+import           Control.Monad (MonadPlus (..))
 import           Control.Monad.Base (MonadBase, liftBase, liftBaseDefault)
 import           Control.Monad.Catch (MonadCatch, catch, MonadThrow, throwM)
 import           Control.Monad.Error.Class
@@ -185,7 +186,7 @@ instance (Monad m, ScottyError e) => MonadPlus (ActionT e m) where
             Left  _ -> runExceptT n
             Right r -> return $ Right r
 
-instance MonadTrans (ActionT e) where
+instance ScottyError e => MonadTrans (ActionT e) where
     lift = ActionT . lift . lift . lift
 
 instance (ScottyError e, Monad m) => MonadError (ActionError e) (ActionT e m) where
@@ -204,7 +205,7 @@ instance (MonadThrow m, ScottyError e) => MonadThrow (ActionT e m) where
 instance (MonadCatch m, ScottyError e) => MonadCatch (ActionT e m) where
     catch (ActionT m) f = ActionT (m `catch` (runAM . f))
 
-instance MonadTransControl (ActionT e) where
+instance ScottyError e => MonadTransControl (ActionT e) where
      type StT (ActionT e) a = StT (StateT ScottyResponse) (StT (ReaderT ActionEnv) (StT (ExceptT (ActionError e)) a))
      liftWith = \f ->
         ActionT $  liftWith $ \run  ->

--- a/scotty.cabal
+++ b/scotty.cabal
@@ -72,26 +72,26 @@ Library
                        Web.Scotty.Route
                        Web.Scotty.Util
   default-language:    Haskell2010
-  build-depends:       aeson                 >= 0.6.2.1  && < 1.6,
-                       base                  >= 4.6      && < 5,
-                       base-compat-batteries >= 0.10     && < 0.13,
-                       blaze-builder         >= 0.3.3.0  && < 0.5,
-                       bytestring            >= 0.10.0.2 && < 0.12,
-                       case-insensitive      >= 1.0.0.1  && < 1.3,
-                       data-default-class    >= 0.0.1    && < 0.2,
-                       exceptions            >= 0.7      && < 0.11,
-                       http-types            >= 0.9.1    && < 0.13,
-                       monad-control         >= 1.0.0.3  && < 1.1,
-                       mtl                   >= 2.1.2    && < 2.3,
-                       network               >= 2.6.0.2  && < 3.2,
-                       regex-compat          >= 0.95.1   && < 0.96,
-                       text                  >= 0.11.3.1 && < 1.3,
-                       transformers          >= 0.3.0.0  && < 0.6,
-                       transformers-base     >= 0.4.1    && < 0.5,
-                       transformers-compat   >= 0.4      && < 0.8,
-                       wai                   >= 3.0.0    && < 3.3,
-                       wai-extra             >= 3.0.0    && < 3.2,
-                       warp                  >= 3.0.13   && < 3.4
+  build-depends:       aeson,
+                       base                  >= 4.7,
+                       base-compat-batteries,
+                       blaze-builder,
+                       bytestring,
+                       case-insensitive,
+                       data-default-class,
+                       exceptions,
+                       http-types,
+                       monad-control,
+                       mtl,
+                       network,
+                       regex-compat,
+                       text,
+                       transformers,
+                       transformers-base,
+                       transformers-compat,
+                       wai,
+                       wai-extra,
+                       warp
 
   if impl(ghc < 8.0)
     build-depends:     fail

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -122,7 +122,7 @@ spec = do
       withApp (Scotty.setMaxRequestBodySize 1 >> Scotty.matchAny "/upload" (do status status200)) $ do
         it "upload endpoint for max-size requests, status 413 if request is too big, 200 otherwise" $ do
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
-            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..1500]::[Integer])]) `shouldRespondWith` 413
+            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..4500]::[Integer])]) `shouldRespondWith` 413
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
             (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..50]::[Integer])]) `shouldRespondWith` 200
 

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -126,7 +126,7 @@ spec = do
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
             (BL.replicate 1025 $ c2w 'a') `shouldRespondWith` 413
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
-            (BL.replicate 1023 $ c2w 'a') `shouldRespondWith` 200
+            (BL.replicate 1024 $ c2w 'a') `shouldRespondWith` 200
 
     describe "text" $ do
       let modernGreekText :: IsString a => a

--- a/test/Web/ScottySpec.hs
+++ b/test/Web/ScottySpec.hs
@@ -21,6 +21,8 @@ import qualified Web.Scotty as Scotty
 import           Control.Concurrent.Async (withAsync)
 import           Control.Exception (bracketOnError)
 import qualified Data.ByteString as BS
+import           Data.ByteString.Internal (c2w)
+import qualified Data.ByteString.Lazy as BL
 import           Data.ByteString (ByteString)
 import           Data.Default.Class (def)
 import           Network.Socket (Family(..), SockAddr(..), Socket, SocketOption(..), SocketType(..), bind, close, connect, listen, maxListenQueue, setSocketOption, socket)
@@ -122,9 +124,9 @@ spec = do
       withApp (Scotty.setMaxRequestBodySize 1 >> Scotty.matchAny "/upload" (do status status200)) $ do
         it "upload endpoint for max-size requests, status 413 if request is too big, 200 otherwise" $ do
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
-            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..4500]::[Integer])]) `shouldRespondWith` 413
+            (BL.replicate 1025 $ c2w 'a') `shouldRespondWith` 413
           request "POST" "/upload" [("Content-Type","multipart/form-data; boundary=--33")]
-            (TLE.encodeUtf8 . TL.pack . concat $ [show c | c <- ([1..50]::[Integer])]) `shouldRespondWith` 200
+            (BL.replicate 1023 $ c2w 'a') `shouldRespondWith` 200
 
     describe "text" $ do
       let modernGreekText :: IsString a => a


### PR DESCRIPTION
- Remove dependency bounds
- Fix some imports + instances
- Remove non-canonical `return`
- Fix a failing test case
- A `requestLimit` test that _actually_ makes sense
- Scotty request size checks.
